### PR TITLE
Handle fstat returning a boolean instead of an array

### DIFF
--- a/src/StreamUtil.php
+++ b/src/StreamUtil.php
@@ -90,7 +90,7 @@ class StreamUtil
     {
         $stat = fstat($stream);
 
-        return $stat['size'];
+        return is_array($stat) && isset($stat['size']) ? $stat['size'] : 0;
     }
 
     /**


### PR DESCRIPTION
Sometimes, though undocumented, `fstat()` can return a boolean. Adding this allows the function to work as expected and prevents notices from being thrown.