### PR TITLE
Fix warnings in getSize() without changing the actual API.

### DIFF
--- a/src/StreamUtil.php
+++ b/src/StreamUtil.php
@@ -84,13 +84,16 @@ class StreamUtil
      *
      * @param resource $stream The stream.
      *
-     * @return int The size of the stream.
+     * @return int|null The size of the stream or NULL if it can't be retrieved.
      */
     public static function getSize($stream)
     {
         $stat = fstat($stream);
+        if ($stat === FALSE) {
+          return NULL;
+        }
 
-        return $stat['size'];
+        return isset($stat['size']) ? $stat['size'] : NULL;
     }
 
     /**


### PR DESCRIPTION
There are multiple attempts to fix this issue already. See #1, #3 and #4. This one is different in that it doesn't break backward compatibility, because it still returns `NULL` in case the size can't be determined, while other PRs change it to `FALSE`. It also doesn't include any special handling for HTTP protocol.